### PR TITLE
added setting hostname in .wakatime.cfg

### DIFF
--- a/wakatime/main.py
+++ b/wakatime/main.py
@@ -185,6 +185,9 @@ def parseArguments():
         return args, configs
 
     # update args from configs
+    if not args.hostname:
+        if configs.has_option('settings', 'hostname'):
+            args.hostname = configs.get('settings', 'hostname')    
     if not args.key:
         default_key = None
         if configs.has_option('settings', 'api_key'):


### PR DESCRIPTION
Hi,

referring to issue #33, when a hostname changes, logging no longer takes place even though the log shows  "DEBUG", "message": {"response_code": 201}}. There is a 201 response code from the WakaTime API so the data is been sent, but with a different host name and thus no logging takes place. I have tested this, changing hostnames causes it to no longers log, changing it back reverts this.

This will simply look for the hostname settings in .wakatime.cfg and if it exist, use that hostname. 

My hostname changes on a weekly basis (working on VM), so this would be helpful. Also if you move between computers, you can just continue logging on the new machine