### PR TITLE
Fix Haxe spelling

### DIFF
--- a/wakatime/languages/default.json
+++ b/wakatime/languages/default.json
@@ -31,7 +31,7 @@
   "groovy": "Groovy", 
   "haml": "Haml", 
   "haskell": "Haskell", 
-  "haxe": "HaXe", 
+  "haxe": "Haxe", 
   "html": "HTML", 
   "ini": "INI", 
   "jade": "Jade", 


### PR DESCRIPTION
"HaXe" is an old spelling that was changed a while ago:

https://groups.google.com/d/msg/haxelang/O7PB-ZrX4i4/uL69CT44C-IJ