### PR TITLE
Adds a strictSSL option

### DIFF
--- a/wakatime/arguments.py
+++ b/wakatime/arguments.py
@@ -165,6 +165,8 @@ def parseArguments():
 
     if not args.exclude:
         args.exclude = []
+    if configs.has_option('settings', 'certFile'):
+        args.certFile = configs.get('settings', 'certFile')
     if configs.has_option('settings', 'ignore'):
         try:
             for pattern in configs.get('settings', 'ignore').split("\n"):

--- a/wakatime/arguments.py
+++ b/wakatime/arguments.py
@@ -165,8 +165,8 @@ def parseArguments():
 
     if not args.exclude:
         args.exclude = []
-    if configs.has_option('settings', 'certFile'):
-        args.certFile = configs.get('settings', 'certFile')
+    if configs.has_option('settings', 'strictSSL'):
+        args.strictSSL = configs.getboolean('settings', 'strictSSL')
     if configs.has_option('settings', 'ignore'):
         try:
             for pattern in configs.get('settings', 'ignore').split("\n"):

--- a/wakatime/arguments.py
+++ b/wakatime/arguments.py
@@ -167,6 +167,8 @@ def parseArguments():
         args.exclude = []
     if configs.has_option('settings', 'strictSSL'):
         args.strictSSL = configs.getboolean('settings', 'strictSSL')
+    else:
+        args.strictSSL = True
     if configs.has_option('settings', 'ignore'):
         try:
             for pattern in configs.get('settings', 'ignore').split("\n"):

--- a/wakatime/main.py
+++ b/wakatime/main.py
@@ -151,7 +151,7 @@ def send_heartbeat(project=None, branch=None, hostname=None, stats={}, key=None,
     response = None
     try:
         response = session.post(api_url, data=request_body, headers=headers,
-                                proxies=proxies, timeout=timeout)
+                                proxies=proxies, timeout=timeout, verify=args.certFile)
     except RequestException:
         exception_data = {
             sys.exc_info()[0].__name__: u(sys.exc_info()[1]),

--- a/wakatime/main.py
+++ b/wakatime/main.py
@@ -62,7 +62,7 @@ from .packages import tzlocal
 def send_heartbeat(project=None, branch=None, hostname=None, stats={}, key=None,
                    entity=None, timestamp=None, is_write=None, plugin=None,
                    offline=None, entity_type='file', hidefilenames=None,
-                   proxy=None, api_url=None, timeout=None, **kwargs):
+                   proxy=None, api_url=None, timeout=None,strictSSL=True, **kwargs):
     """Sends heartbeat as POST request to WakaTime api server.
 
     Returns `SUCCESS` when heartbeat was sent, otherwise returns an
@@ -151,7 +151,7 @@ def send_heartbeat(project=None, branch=None, hostname=None, stats={}, key=None,
     response = None
     try:
         response = session.post(api_url, data=request_body, headers=headers,
-                                proxies=proxies, timeout=timeout, verify=args.certFile)
+                                proxies=proxies, timeout=timeout, verify=strictSSL)
     except RequestException:
         exception_data = {
             sys.exc_info()[0].__name__: u(sys.exc_info()[1]),
@@ -240,6 +240,7 @@ def sync_offline_heartbeats(args, hostname):
             proxy=args.proxy,
             api_url=args.api_url,
             timeout=args.timeout,
+            strictSSL=args.strictSSL
         )
         if status != SUCCESS:
             if status == AUTH_ERROR:
@@ -287,6 +288,7 @@ def process_heartbeat(args, configs, hostname, heartbeat):
         heartbeat['hidefilenames'] = args.hidefilenames
         heartbeat['proxy'] = args.proxy
         heartbeat['api_url'] = args.api_url
+        heartbeat['strictSSL'] = args.strictSSL
 
         return send_heartbeat(**heartbeat)
 


### PR DESCRIPTION
by default it is set to true in send_heartbeat as that is the recommended practice from a security point of view. Also it is True by default within the requests package.

It is configurable within the wakatime.cfg