### PR TITLE
Fix bug when sending heartbeats with hidefilenames enabled

### DIFF
--- a/wakatime/main.py
+++ b/wakatime/main.py
@@ -107,9 +107,9 @@ def send_heartbeat(project=None, branch=None, hostname=None, stats={}, key=None,
 
                     # also delete any sensitive info when hiding file names
                     sensitive = ['dependencies', 'lines', 'lineno', 'cursorpos', 'branch']
-                    for key in sensitive:
-                        if key in data:
-                            del data[key]
+                    for sensitiveKey in sensitive:
+                        if sensitiveKey in data:
+                            del data[sensitiveKey]
 
                     break
             except re.error as ex:


### PR DESCRIPTION
When `hidefilenames` is enabled, the argument `key` of `send_heartbeat` method is overwritten by for loop in line 110.

This results in an invalid API call, which responds with `401 Unauthorized`, since the api key is invalid.