### PR TITLE
Remove empty return

### DIFF
--- a/wakatime/api.py
+++ b/wakatime/api.py
@@ -179,25 +179,23 @@ def send_heartbeats(heartbeats, args, configs, use_ntlm_proxy=False):
 
 
 def handle_result(h, code, content, args, configs):
-    if code == requests.codes.created or code == requests.codes.accepted:
-        return
-
-    if args.offline:
-        if code == 400:
+    if code != requests.codes.created and code != requests.codes.accepted:
+        if args.offline:
+            if code == 400:
+                log.error({
+                    'response_code': code,
+                    'response_content': content,
+                })
+            else:
+                if log.isEnabledFor(logging.DEBUG):
+                    log.warn({
+                        'response_code': code,
+                        'response_content': content,
+                    })
+                queue = Queue(args, configs)
+                queue.push_many(h)
+        else:
             log.error({
                 'response_code': code,
                 'response_content': content,
             })
-        else:
-            if log.isEnabledFor(logging.DEBUG):
-                log.warn({
-                    'response_code': code,
-                    'response_content': content,
-                })
-            queue = Queue(args, configs)
-            queue.push_many(h)
-    else:
-        log.error({
-            'response_code': code,
-            'response_content': content,
-        })


### PR DESCRIPTION
Sacrifice 1 character on one line to remove another.

My goal isn't necessarily to make the script smaller marginally by 1 line, but the convention is typically to avoid empty returns if at all possible. Here, this is possible.