### PR TITLE
feat: Support non-mapped network drives on Windows.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,18 @@ class UtilsTestCase(TestCase):
                 result = format_file_path(path)
                 self.assertPathsEqual(expected, result)
 
+    def test_format_file_path_windows_network_mount(self):
+        path = '\\\\some\\path////to\\\\\\a\\file.txt'
+        expected = '//some/path/to/a/file.txt'
+
+        with mock.patch('os.path.realpath') as mock_realpath:
+            mock_realpath.return_value = path
+            with mock.patch('os.path.abspath') as mock_abspath:
+                mock_abspath.return_value = path
+
+                result = format_file_path(path)
+                self.assertPathsEqual(expected, result)
+
     def test_format_file_path_handles_exceptions(self):
         path = 'c:\\some\\path////to\\\\\\a\\file.txt'
         expected = path

--- a/wakatime/heartbeat.py
+++ b/wakatime/heartbeat.py
@@ -255,6 +255,9 @@ class Heartbeat(object):
         if self._file_exists():
             return
 
+        if not self.entity:
+            return
+
         self.args.local_file = self._to_unc_path(self.entity)
 
     def _to_unc_path(self, filepath):

--- a/wakatime/utils.py
+++ b/wakatime/utils.py
@@ -26,7 +26,7 @@ log = logging.getLogger('WakaTime')
 
 BACKSLASH_REPLACE_PATTERN = re.compile(r'[\\/]+')
 WINDOWS_DRIVE_PATTERN = re.compile(r'^[a-z]:/')
-WINDOWS_NETWORK_MOUNT_PATTERN = re.compile(r'^\\{2}[a-z]+')
+WINDOWS_NETWORK_MOUNT_PATTERN = re.compile(r'^\\{2}[a-z]+', re.IGNORECASE)
 
 
 def should_exclude(entity, include, exclude):

--- a/wakatime/utils.py
+++ b/wakatime/utils.py
@@ -26,6 +26,7 @@ log = logging.getLogger('WakaTime')
 
 BACKSLASH_REPLACE_PATTERN = re.compile(r'[\\/]+')
 WINDOWS_DRIVE_PATTERN = re.compile(r'^[a-z]:/')
+WINDOWS_NETWORK_MOUNT_PATTERN = re.compile(r'^\\{2}[a-z]+')
 
 
 def should_exclude(entity, include, exclude):
@@ -77,10 +78,15 @@ def format_file_path(filepath):
     """Formats a path as absolute and with the correct platform separator."""
 
     try:
+        is_windows_network_mount = WINDOWS_NETWORK_MOUNT_PATTERN.match(filepath)
         filepath = os.path.realpath(os.path.abspath(filepath))
         filepath = re.sub(BACKSLASH_REPLACE_PATTERN, '/', filepath)
         if WINDOWS_DRIVE_PATTERN.match(filepath):
             filepath = filepath.capitalize()
+        if is_windows_network_mount:
+            # Add back a / to the front, since the previous modifications
+            # will have replaced any double slashes with single
+            filepath = '/' + filepath
     except:
         pass
     return filepath


### PR DESCRIPTION
Adds support for tracking files on network drives that are not mapped to a specific drive letter (e.g. X:\), but rather using a UNC path directly to the share, e.g. \\Mac\Home\Documents.

I've verified that this fixes https://github.com/wakatime/visualstudio-wakatime/issues/82 on my own VS setup which uses network mounted shares. :-)

First time contributing here, so feel free to poke me with any questions or thoughts.

Happy holidays!